### PR TITLE
azhou - Fixed Personal Schedule Default Quarter Bug

### DIFF
--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,8 +20,6 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
-
-
   const localSearchQuarter = localStorage.getItem(controlId);
 
   const [quarterState, setQuarterState] = useState(

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,11 +20,13 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
+
+
   const localSearchQuarter = localStorage.getItem(controlId);
 
   const [quarterState, setQuarterState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
-    localSearchQuarter || quarters[0].yyyyq,
+    localSearchQuarter ? localSearchQuarter : quarters[0].yyyyq
   );
 
   const handleQuarterOnChange = (event) => {

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,11 +20,13 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
+  if (!localStorage.getItem(controlId)) {
+    localStorage.setItem(controlId, quarters[0].yyyyq);
+  }
   const localSearchQuarter = localStorage.getItem(controlId);
-
   const [quarterState, setQuarterState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
-    localSearchQuarter ? localSearchQuarter : quarters[0].yyyyq,
+    localSearchQuarter || quarters[0].yyyyq,
   );
 
   const handleQuarterOnChange = (event) => {

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -24,7 +24,7 @@ function SingleQuarterDropdown({
 
   const [quarterState, setQuarterState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
-    localSearchQuarter ? localSearchQuarter : quarters[0].yyyyq
+    localSearchQuarter ? localSearchQuarter : quarters[0].yyyyq,
   );
 
   const handleQuarterOnChange = (event) => {

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,10 +20,10 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
-  if (!localStorage.getItem(controlId)) {
+  localStorage.getItem(controlId) === null &&
     localStorage.setItem(controlId, quarters[0].yyyyq);
-  }
   const localSearchQuarter = localStorage.getItem(controlId);
+
   const [quarterState, setQuarterState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
     localSearchQuarter || quarters[0].yyyyq,


### PR DESCRIPTION
NOT WORKING

In this PR, we fix the issue of personal schedule creation failing before the quarter field is changed. 

Dokku Link: https://proj-courses-apzhou0-dev.dokku-12.cs.ucsb.edu/

To test, click on the link above and log in. Click on "Personal Schedules," select "Add Schedule," and enter a name and description but click "create" without changing the quarter. No errors should appear.

Storybook Link: https://ucsb-cs156-f23.github.io/proj-courses-f23-7pm-4/prs/25/storybook/?path=/docs/pages-personalschedules-personalschedulescreatepage--default
 
Closes #11