### PR TITLE
azhou - Personal Schedule Default Quarter Fix

### DIFF
--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -20,6 +20,9 @@ function SingleQuarterDropdown({
   onChange = null,
   label = "Quarter",
 }) {
+  if (!localStorage.getItem(controlId)) {
+    localStorage.setItem(controlId, quarters[0].yyyyq);
+  }
   const localSearchQuarter = localStorage.getItem(controlId);
 
   const [quarterState, setQuarterState] = useState(

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -130,7 +130,7 @@ describe("SingleQuarterSelector tests", () => {
     await waitFor(() => expect(useState).toBeCalledWith("20202"));
   });
 
-  test("when localstorage has no value, first element of quarter range is passed to useState and ", async () => {
+  test("when localstorage has no value, first element of quarter range is passed to useState", async () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => null);
 

--- a/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
+++ b/frontend/src/tests/components/Quarters/SingleQuarterDropdown.test.js
@@ -130,7 +130,7 @@ describe("SingleQuarterSelector tests", () => {
     await waitFor(() => expect(useState).toBeCalledWith("20202"));
   });
 
-  test("when localstorage has no value, first element of quarter range is passed to useState", async () => {
+  test("when localstorage has no value, first element of quarter range is passed to useState and ", async () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
     getItemSpy.mockImplementation(() => null);
 
@@ -147,5 +147,23 @@ describe("SingleQuarterSelector tests", () => {
     );
 
     await waitFor(() => expect(useState).toBeCalledWith("20201"));
+  });
+
+  test("when localstorage has no value, localstorage is set to first element of quarters", async () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+    getItemSpy.mockImplementation(() => null);
+
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+
+    render(
+      <SingleQuarterDropdown
+        quarters={quarterRange("20201", "20224")}
+        quarter={quarter}
+        setQuarter={setQuarter}
+        controlId="sqd1"
+      />,
+    );
+
+    await waitFor(() => expect(setItemSpy).toBeCalledWith("sqd1", "20201"));
   });
 });


### PR DESCRIPTION
In this PR, we fix the issue of personal schedule creation failing before the quarter field is changed. 

Dokku Link: https://proj-courses-apzhou0-dev.dokku-12.cs.ucsb.edu/

To test, click on the link above and log in. Click on "Personal Schedules," select "Add Schedule," and enter a name and description but click "create" without changing the quarter. No errors should appear. Also try the same thing using incognito mode, as this should reset localStorage. 
 
Closes #11