### PR TITLE
EricM5 - Fix Bug 'Search by Instructor's '+' button in table does nothing'

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -14,7 +14,7 @@ function getFirstVal(values) {
   return values[0];
 }
 
-export default function SectionsTable(props) {
+export default function SectionsTable({sections, canExpand=true}) {
   // Stryker enable all
   // Stryker disable BooleanLiteral
   const columns = [
@@ -110,10 +110,10 @@ export default function SectionsTable(props) {
 
   return (
     <SectionsTableBase
-      data={props.sections}
+      data={sections}
       columns={columnsToDisplay}
       testid={testid}
-      page={props.page}
+      canExpand={canExpand}
     />
   );
 }

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -14,7 +14,7 @@ function getFirstVal(values) {
   return values[0];
 }
 
-export default function SectionsTable({sections, canExpand=true}) {
+export default function SectionsTable({ sections, canExpand = true }) {
   // Stryker enable all
   // Stryker disable BooleanLiteral
   const columns = [

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -17,8 +17,6 @@ function getFirstVal(values) {
 export default function SectionsTable(props) {
   // Stryker enable all
   // Stryker disable BooleanLiteral
-
-  console.log(props);
   const columns = [
     {
       Header: "Quarter",

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -14,9 +14,11 @@ function getFirstVal(values) {
   return values[0];
 }
 
-export default function SectionsTable({ sections }) {
+export default function SectionsTable(props) {
   // Stryker enable all
   // Stryker disable BooleanLiteral
+
+  console.log(props);
   const columns = [
     {
       Header: "Quarter",
@@ -110,9 +112,10 @@ export default function SectionsTable({ sections }) {
 
   return (
     <SectionsTableBase
-      data={sections}
+      data={props.sections}
       columns={columnsToDisplay}
       testid={testid}
+      page={props.page}
     />
   );
 }

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -7,6 +7,7 @@ export default function SectionsTableBase({
   columns,
   data,
   testid = "testid",
+  page,
 }) {
   // Stryker disable next-line ObjectLiteral
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
@@ -73,6 +74,7 @@ export default function SectionsTableBase({
                       >
                         {cell.isGrouped ? (
                           <>
+                            {page !== "CourseOverTimeInstructor" && (
                             <span
                               {...row.getToggleRowExpandedProps()}
                               data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}
@@ -82,7 +84,8 @@ export default function SectionsTableBase({
                                   ? "➖ "
                                   : "➕ "
                                 : null}
-                            </span>{" "}
+                            </span>
+                            )}
                             {cell.render("Cell")}
                           </>
                         ) : cell.isAggregated ? (

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -21,7 +21,7 @@ export default function SectionsTableBase({
         data,
       },
       useGroupBy,
-      useExpanded,
+      useExpanded
     );
 
   return (
@@ -75,16 +75,16 @@ export default function SectionsTableBase({
                         {cell.isGrouped ? (
                           <>
                             {page !== "CourseOverTimeInstructor" && (
-                            <span
-                              {...row.getToggleRowExpandedProps()}
-                              data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}
-                            >
-                              {row.subRows.length > 1
-                                ? row.isExpanded
-                                  ? "➖ "
-                                  : "➕ "
-                                : null}
-                            </span>
+                              <span
+                                {...row.getToggleRowExpandedProps()}
+                                data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}
+                              >
+                                {row.subRows.length > 1
+                                  ? row.isExpanded
+                                    ? "➖ "
+                                    : "➕ "
+                                  : null}
+                              </span>
                             )}
                             {cell.render("Cell")}
                           </>

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -7,7 +7,7 @@ export default function SectionsTableBase({
   columns,
   data,
   testid = "testid",
-  page,
+  canExpand = true,
 }) {
   // Stryker disable next-line ObjectLiteral
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
@@ -74,7 +74,7 @@ export default function SectionsTableBase({
                       >
                         {cell.isGrouped ? (
                           <>
-                            {page !== "CourseOverTimeInstructor" && (
+                            {canExpand && (
                               <span
                                 {...row.getToggleRowExpandedProps()}
                                 data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -21,7 +21,7 @@ export default function SectionsTableBase({
         data,
       },
       useGroupBy,
-      useExpanded
+      useExpanded,
     );
 
   return (

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
@@ -26,7 +26,7 @@ export default function CourseOverTimeInstructorIndexPage() {
     objectToAxiosParams,
     { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
-    []
+    [],
   );
 
   async function fetchCourseOverTimeJSON(_event, query) {
@@ -40,7 +40,7 @@ export default function CourseOverTimeInstructorIndexPage() {
         <CourseOverTimeInstructorSearchForm
           fetchJSON={fetchCourseOverTimeJSON}
         />
-        <SectionsTable sections={courseJSON} page="CourseOverTimeInstructor"/>
+        <SectionsTable sections={courseJSON} page="CourseOverTimeInstructor" />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
@@ -40,7 +40,7 @@ export default function CourseOverTimeInstructorIndexPage() {
         <CourseOverTimeInstructorSearchForm
           fetchJSON={fetchCourseOverTimeJSON}
         />
-        <SectionsTable sections={courseJSON} page="CourseOverTimeInstructor" />
+        <SectionsTable sections={courseJSON} canExpand={false} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
@@ -26,7 +26,7 @@ export default function CourseOverTimeInstructorIndexPage() {
     objectToAxiosParams,
     { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
-    [],
+    []
   );
 
   async function fetchCourseOverTimeJSON(_event, query) {
@@ -40,7 +40,7 @@ export default function CourseOverTimeInstructorIndexPage() {
         <CourseOverTimeInstructorSearchForm
           fetchJSON={fetchCourseOverTimeJSON}
         />
-        <SectionsTable sections={courseJSON} page="CourseOverTimeInstructor"/>
+        <SectionsTable sections={courseJSON} page="CourseOverTimeInstructor" />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
@@ -40,7 +40,7 @@ export default function CourseOverTimeInstructorIndexPage() {
         <CourseOverTimeInstructorSearchForm
           fetchJSON={fetchCourseOverTimeJSON}
         />
-        <SectionsTable sections={courseJSON} />
+        <SectionsTable sections={courseJSON} page="CourseOverTimeInstructor"/>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
@@ -40,7 +40,7 @@ export default function CourseOverTimeInstructorIndexPage() {
         <CourseOverTimeInstructorSearchForm
           fetchJSON={fetchCourseOverTimeJSON}
         />
-        <SectionsTable sections={courseJSON} page="CourseOverTimeInstructor" />
+        <SectionsTable sections={courseJSON} page="CourseOverTimeInstructor"/>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -113,7 +113,7 @@ describe("SectionsTableBase tests", () => {
 
   test("renders an full table without crashing", () => {
     render(
-      <SectionsTableBase columns={columns} data={gigaSections} group={false} />
+      <SectionsTableBase columns={columns} data={gigaSections} group={false} />,
     );
   });
 
@@ -123,7 +123,7 @@ describe("SectionsTableBase tests", () => {
         columns={columns}
         data={oneLectureSectionWithNoDiscussion}
         group={false}
-      />
+      />,
     );
 
     expect(screen.queryByText("➖")).not.toBeInTheDocument();
@@ -132,21 +132,21 @@ describe("SectionsTableBase tests", () => {
 
   test("renders five sections (one with no discussion then lecture with three discussions) correctly", async () => {
     render(
-      <SectionsTableBase columns={columns} data={fiveSections} group={false} />
+      <SectionsTableBase columns={columns} data={fiveSections} group={false} />,
     );
 
     expect(screen.getByText("➕")).toBeInTheDocument();
     expect(screen.queryByText("➖")).not.toBeInTheDocument();
     expect(
       screen.getByTestId(
-        "testid-cell-row-1-col-courseInfo.courseId-expand-symbols"
-      )
+        "testid-cell-row-1-col-courseInfo.courseId-expand-symbols",
+      ),
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId")
+      screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId"),
     ).toHaveAttribute(
       "style",
-      "background: rgb(52, 133, 155); color: rgb(239, 252, 244); font-weight: bold;"
+      "background: rgb(52, 133, 155); color: rgb(239, 252, 244); font-weight: bold;",
     );
   });
 
@@ -157,7 +157,7 @@ describe("SectionsTableBase tests", () => {
         data={fiveSections}
         group={false}
         page="CourseOverTimeInstructor"
-      />
+      />,
     );
     expect(screen.queryByText("➖")).not.toBeInTheDocument();
     expect(screen.queryByText("➕")).not.toBeInTheDocument();

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -113,7 +113,7 @@ describe("SectionsTableBase tests", () => {
 
   test("renders an full table without crashing", () => {
     render(
-      <SectionsTableBase columns={columns} data={gigaSections} group={false} />,
+      <SectionsTableBase columns={columns} data={gigaSections} group={false} />
     );
   });
 
@@ -123,7 +123,7 @@ describe("SectionsTableBase tests", () => {
         columns={columns}
         data={oneLectureSectionWithNoDiscussion}
         group={false}
-      />,
+      />
     );
 
     expect(screen.queryByText("➖")).not.toBeInTheDocument();
@@ -132,29 +132,34 @@ describe("SectionsTableBase tests", () => {
 
   test("renders five sections (one with no discussion then lecture with three discussions) correctly", async () => {
     render(
-      <SectionsTableBase columns={columns} data={fiveSections} group={false} />,
+      <SectionsTableBase columns={columns} data={fiveSections} group={false} />
     );
 
     expect(screen.getByText("➕")).toBeInTheDocument();
     expect(screen.queryByText("➖")).not.toBeInTheDocument();
     expect(
       screen.getByTestId(
-        "testid-cell-row-1-col-courseInfo.courseId-expand-symbols",
-      ),
+        "testid-cell-row-1-col-courseInfo.courseId-expand-symbols"
+      )
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId"),
+      screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId")
     ).toHaveAttribute(
       "style",
-      "background: rgb(52, 133, 155); color: rgb(239, 252, 244); font-weight: bold;",
+      "background: rgb(52, 133, 155); color: rgb(239, 252, 244); font-weight: bold;"
     );
   });
 
   test("when on Instructor Search Page, No +/- is displayed for dropdown", () => {
     render(
-      <SectionsTableBase columns={columns} data={fiveSections} group={false} page="CourseOverTimeInstructor"/>,
+      <SectionsTableBase
+        columns={columns}
+        data={fiveSections}
+        group={false}
+        page="CourseOverTimeInstructor"
+      />
     );
     expect(screen.queryByText("➖")).not.toBeInTheDocument();
     expect(screen.queryByText("➕")).not.toBeInTheDocument();
-  })
+  });
 });

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -150,7 +150,7 @@ describe("SectionsTableBase tests", () => {
     );
   });
 
-  test("when canExpand set to false, no dropdown buttons are displayed, ", () => {
+  test("when canExpand set to false, no dropdown buttons are displayed", () => {
     render(
       <SectionsTableBase
         columns={columns}

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -162,6 +162,4 @@ describe("SectionsTableBase tests", () => {
     expect(screen.queryByText("➖")).not.toBeInTheDocument();
     expect(screen.queryByText("➕")).not.toBeInTheDocument();
   });
-
-
 });

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -156,7 +156,7 @@ describe("SectionsTableBase tests", () => {
         columns={columns}
         data={fiveSections}
         group={false}
-        page="CourseOverTimeInstructor"
+        canExpand={false}
       />,
     );
     expect(screen.queryByText("➖")).not.toBeInTheDocument();

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -150,7 +150,7 @@ describe("SectionsTableBase tests", () => {
     );
   });
 
-  test("when on Instructor Search Page, No +/- is displayed for dropdown", () => {
+  test("when canExpand set to false, no dropdown buttons are displayed, ", () => {
     render(
       <SectionsTableBase
         columns={columns}
@@ -162,4 +162,6 @@ describe("SectionsTableBase tests", () => {
     expect(screen.queryByText("➖")).not.toBeInTheDocument();
     expect(screen.queryByText("➕")).not.toBeInTheDocument();
   });
+
+
 });

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -149,4 +149,12 @@ describe("SectionsTableBase tests", () => {
       "background: rgb(52, 133, 155); color: rgb(239, 252, 244); font-weight: bold;",
     );
   });
+
+  test("when on Instructor Search Page, No +/- is displayed for dropdown", () => {
+    render(
+      <SectionsTableBase columns={columns} data={fiveSections} group={false} page="CourseOverTimeInstructor"/>,
+    );
+    expect(screen.queryByText("➖")).not.toBeInTheDocument();
+    expect(screen.queryByText("➕")).not.toBeInTheDocument();
+  })
 });

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.test.js
@@ -10,9 +10,6 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { threeSections } from "fixtures/sectionFixtures";
 import { allTheSubjects } from "fixtures/subjectFixtures";
 import userEvent from "@testing-library/user-event";
-// import SectionsTable from "/Users/ericmarzouk/Desktop/cs156/proj-courses-f23-7pm-4/frontend/src/main/components/Sections/SectionsTable.js"
-import SectionsTable from "main/components/Sections/SectionsTable";
-import { fiveSections, gigaSections } from "fixtures/sectionFixtures";
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.test.js
@@ -129,6 +129,4 @@ describe("CourseOverTimeInstructorIndexPage tests", () => {
     expect(screen.queryByText("➖")).not.toBeInTheDocument();
     expect(screen.queryByText("➕")).not.toBeInTheDocument();
   });
-
-  
 });

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.test.js
@@ -10,6 +10,9 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { threeSections } from "fixtures/sectionFixtures";
 import { allTheSubjects } from "fixtures/subjectFixtures";
 import userEvent from "@testing-library/user-event";
+// import SectionsTable from "/Users/ericmarzouk/Desktop/cs156/proj-courses-f23-7pm-4/frontend/src/main/components/Sections/SectionsTable.js"
+import SectionsTable from "main/components/Sections/SectionsTable";
+import { fiveSections, gigaSections } from "fixtures/sectionFixtures";
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
@@ -89,4 +92,46 @@ describe("CourseOverTimeInstructorIndexPage tests", () => {
 
     expect(screen.getByText("ECE 1A")).toBeInTheDocument();
   });
+
+  test("No +/- is displayed for dropdown", async () => {
+    axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+    axiosMock
+      .onGet("/api/public/courseovertime/instructorsearch")
+      .reply(200, threeSections);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeInstructorIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const selectStartQuarter = screen.getByLabelText("Start Quarter");
+    userEvent.selectOptions(selectStartQuarter, "20222");
+    const selectEndQuarter = screen.getByLabelText("End Quarter");
+    userEvent.selectOptions(selectEndQuarter, "20222");
+    const enterInstructor = screen.getByLabelText("Instructor Name");
+    userEvent.type(enterInstructor, "CONRAD");
+    const selectCheckbox = screen.getByTestId(
+      "CourseOverTimeInstructorSearchForm-checkbox",
+    );
+    userEvent.click(selectCheckbox);
+
+    const submitButton = screen.getByText("Submit");
+    expect(submitButton).toBeInTheDocument();
+    userEvent.click(submitButton);
+
+    axiosMock.resetHistory();
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    expect(screen.getByText("ECE 1A")).toBeInTheDocument();
+    expect(screen.queryByText("➖")).not.toBeInTheDocument();
+    expect(screen.queryByText("➕")).not.toBeInTheDocument();
+  });
+
+  
 });


### PR DESCRIPTION
Fixed bug.

When on Search By Instructor page, I pass in a new attribute (to a prop) to tell the table which page that is sending the form. If the page field == 'CourseOverTimeInstructor', then the table will omit the options to display the '+' and '-', eliminating the dropdown option.


After Edit:

<img width="1130" alt="image" src="https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-4/assets/76453820/d80d0340-9296-429f-89a3-7a09672e2d1b">


closes #2 