### PR TITLE
Azhu- Update slf4j set up to use Lombok annotations instead

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -6,9 +6,9 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,9 +18,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/public/courseovertime")
+@Slf4j
 public class CourseOverTimeBuildingController {
-
-  private final Logger logger = LoggerFactory.getLogger(CourseOverTimeBuildingController.class);
 
   private ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -6,7 +6,6 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -6,7 +6,6 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/public/courseovertime")
-@Slf4j
 public class CourseOverTimeBuildingController {
 
   private ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/public/courseovertime")
 public class CourseOverTimeBuildingController {
-
   private ObjectMapper mapper = new ObjectMapper();
 
   @Autowired ConvertedSectionCollection convertedSectionCollection;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
@@ -6,7 +6,6 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
@@ -6,7 +6,6 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/public/courseovertime")
-@Slf4j
 public class CourseOverTimeController {
 
   private ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/public/courseovertime")
 public class CourseOverTimeController {
-
   private ObjectMapper mapper = new ObjectMapper();
 
   @Autowired ConvertedSectionCollection convertedSectionCollection;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
@@ -6,9 +6,9 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,9 +18,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/public/courseovertime")
+@Slf4j
 public class CourseOverTimeController {
-
-  private final Logger logger = LoggerFactory.getLogger(CourseOverTimeController.class);
 
   private ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorController.java
@@ -6,7 +6,6 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/public/courseovertime")
 public class CourseOverTimeInstructorController {
-
   private ObjectMapper mapper = new ObjectMapper();
 
   @Autowired ConvertedSectionCollection convertedSectionCollection;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorController.java
@@ -6,9 +6,9 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,9 +18,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/public/courseovertime")
+@Slf4j
 public class CourseOverTimeInstructorController {
-
-  private final Logger logger = LoggerFactory.getLogger(CourseOverTimeInstructorController.class);
 
   private ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorController.java
@@ -6,7 +6,6 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/public/courseovertime")
-@Slf4j
 public class CourseOverTimeInstructorController {
 
   private ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,8 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/public")
+@Slf4j
 public class UCSBCurriculumController {
-  private final Logger logger = LoggerFactory.getLogger(UCSBCurriculumController.class);
 
   private ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
-import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/public")
-@Slf4j
 public class UCSBCurriculumController {
 
   private ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/public")
 public class UCSBCurriculumController {
-
   private ObjectMapper mapper = new ObjectMapper();
 
   @Autowired UserRepository userRepository;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsController.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,8 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/sections")
+@Slf4j
 public class UCSBSectionsController {
-  private final Logger logger = LoggerFactory.getLogger(UCSBSectionsController.class);
 
   private ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/sections")
 public class UCSBSectionsController {
-
   private ObjectMapper mapper = new ObjectMapper();
 
   @Autowired UserRepository userRepository;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsController.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsController.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
-import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/sections")
-@Slf4j
 public class UCSBSectionsController {
 
   private ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -13,12 +13,12 @@ import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -30,9 +30,8 @@ import org.springframework.test.web.servlet.MvcResult;
 @WebMvcTest(value = CourseOverTimeBuildingController.class)
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
+@Slf4j
 public class CourseOverTimeBuildingControllerTests {
-  private final Logger logger =
-      LoggerFactory.getLogger(CourseOverTimeBuildingControllerTests.class);
   private ObjectMapper mapper = new ObjectMapper();
 
   @Autowired private MockMvc mockMvc;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -13,7 +13,6 @@ import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +29,6 @@ import org.springframework.test.web.servlet.MvcResult;
 @WebMvcTest(value = CourseOverTimeBuildingController.class)
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
-@Slf4j
 public class CourseOverTimeBuildingControllerTests {
   private ObjectMapper mapper = new ObjectMapper();
 

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -13,7 +13,6 @@ import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
@@ -13,7 +13,6 @@ import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +29,6 @@ import org.springframework.test.web.servlet.MvcResult;
 @WebMvcTest(value = CourseOverTimeController.class)
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
-@Slf4j
 public class CourseOverTimeControllerTests {
   private ObjectMapper mapper = new ObjectMapper();
 

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
@@ -13,7 +13,6 @@ import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
@@ -13,12 +13,12 @@ import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -30,8 +30,8 @@ import org.springframework.test.web.servlet.MvcResult;
 @WebMvcTest(value = CourseOverTimeController.class)
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
+@Slf4j
 public class CourseOverTimeControllerTests {
-  private final Logger logger = LoggerFactory.getLogger(CourseOverTimeControllerTests.class);
   private ObjectMapper mapper = new ObjectMapper();
 
   @Autowired private MockMvc mockMvc;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
@@ -13,7 +13,6 @@ import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
@@ -13,7 +13,6 @@ import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +29,6 @@ import org.springframework.test.web.servlet.MvcResult;
 @WebMvcTest(value = CourseOverTimeInstructorController.class)
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
-@Slf4j
 public class CourseOverTimeInstructorControllerTests {
   private ObjectMapper mapper = new ObjectMapper();
 

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeInstructorControllerTests.java
@@ -13,12 +13,12 @@ import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -30,9 +30,8 @@ import org.springframework.test.web.servlet.MvcResult;
 @WebMvcTest(value = CourseOverTimeInstructorController.class)
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
+@Slf4j
 public class CourseOverTimeInstructorControllerTests {
-  private final Logger logger =
-      LoggerFactory.getLogger(CourseOverTimeInstructorControllerTests.class);
   private ObjectMapper mapper = new ObjectMapper();
 
   @Autowired private MockMvc mockMvc;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -10,9 +10,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import lombok.extern.slf4j.Slf4j;
+
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -24,8 +24,9 @@ import org.springframework.test.web.servlet.MvcResult;
 @WebMvcTest(value = UCSBCurriculumController.class)
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
+@Slf4j
 public class UCSBCurriculumControllerTests {
-  private final Logger logger = LoggerFactory.getLogger(UCSBCurriculumControllerTests.class);
+
   private ObjectMapper mapper = new ObjectMapper();
 
   @MockBean UserRepository userRepository;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -24,7 +24,6 @@ import org.springframework.test.web.servlet.MvcResult;
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
 public class UCSBCurriculumControllerTests {
-
   private ObjectMapper mapper = new ObjectMapper();
 
   @MockBean UserRepository userRepository;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
-import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +23,6 @@ import org.springframework.test.web.servlet.MvcResult;
 @WebMvcTest(value = UCSBCurriculumController.class)
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
-@Slf4j
 public class UCSBCurriculumControllerTests {
 
   private ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
@@ -10,9 +10,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import lombok.extern.slf4j.Slf4j;
+
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -24,8 +24,8 @@ import org.springframework.test.web.servlet.MvcResult;
 @WebMvcTest(value = UCSBSectionsController.class)
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
+@Slf4j
 public class UCSBSectionsControllerTests {
-  private final Logger logger = LoggerFactory.getLogger(UCSBSectionsControllerTests.class);
   private ObjectMapper mapper = new ObjectMapper();
 
   @MockBean UserRepository userRepository;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.courses.config.SecurityConfig;
 import edu.ucsb.cs156.courses.repositories.UserRepository;
 import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
-import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +23,6 @@ import org.springframework.test.web.servlet.MvcResult;
 @WebMvcTest(value = UCSBSectionsController.class)
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
-@Slf4j
 public class UCSBSectionsControllerTests {
   private ObjectMapper mapper = new ObjectMapper();
 


### PR DESCRIPTION
We used to initialize logger like this
```java
private final Logger logger = LoggerFactory.getLogger(CourseInstructorController.class);
```
but now we prefer to use the Lombok annotation 
```java
@Slf4j
```

In this PR, we replace remove all instances of 
```java
private final Logger logger = LoggerFactory.getLogger(CourseInstructorController.class);
```
Since there were no usages of `logger` in those files, we also do not re-add 
```java
@Slf4j
```

Closes #6