### PR TITLE
EricM5 - Display SystemInfo on Developer Page

### DIFF
--- a/frontend/src/main/pages/DeveloperPage.js
+++ b/frontend/src/main/pages/DeveloperPage.js
@@ -1,10 +1,19 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { Row } from "react-bootstrap";
+import ReactJson from "react-json-view";
+import { useSystemInfo } from "main/utils/systemInfo";
 
 const DeveloperPage = () => {
+  const { data: systemInfo } = useSystemInfo();
+
   return (
     <BasicLayout>
       <h2>Welcome to the Developer Page!</h2>
+      <hr></hr>
+      <Row className="text-left">
+        <ReactJson src={systemInfo} />
+      </Row>
     </BasicLayout>
   );
 };

--- a/frontend/src/stories/pages/DeveloperPage.stories.js
+++ b/frontend/src/stories/pages/DeveloperPage.stories.js
@@ -1,10 +1,21 @@
 import React from "react";
 
 import DeveloperPage from "main/pages/DeveloperPage";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 export default {
   title: "pages/DeveloperPage",
   component: DeveloperPage,
+  parameters: {
+    mockData: [
+      {
+        url: "/api/systemInfo",
+        method: "GET",
+        status: 200,
+        response: systemInfoFixtures.showingBoth,
+      },
+    ],
+  },
 };
 
 const Template = () => <DeveloperPage />;


### PR DESCRIPTION
(Should be merged after PR #39 )

Part of Issue #8 **(This is the end of frontend from this issue)**


When navigating to developer page, one can see the systeminfo json retrieved from the /api/systeminfo json endpoint in the body of the developer page.

(just backend with /api/systeminfo needs to be implemented)

Dokku Link: https://proj-courses-ericm5-dev.dokku-12.cs.ucsb.edu/
Storybook: https://ucsb-cs156-f23.github.io/proj-courses-f23-7pm-4/prs/42/storybook/?path=/docs/pages-developerpage--default

Final Product:
<img width="1430" alt="image" src="https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-4/assets/76453820/78f421f8-a17c-481b-92d9-af4a1f755581">


closes #41 