### PR TITLE
azhou - Fixed typo in footer

### DIFF
--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -65,7 +65,7 @@ export default function Footer(systemInfo) {
         <p>
           The cartoon Storke Tower images in the brand logo and favicon for this
           site were developed by Chelsea Lyon-Hayden, Art Director for UCSB
-          Associate Students, and are used here by permission of the Executive
+          Associated Students, and are used here by permission of the Executive
           Director of UCSB Associated Students. These images are Copyright ©
           2021 UCSB Associated Students, and may not be reused without express
           written permission of the Executive Director of UCSB Associated


### PR DESCRIPTION
In this PR, we fix a typo in the footer. 

"Art Director for UCSB Associate Students" has been changed to "Art Director for UCSB Associated Students" 