### PR TITLE
Sasha - EPIC for better job logs, Part 1

### DIFF
--- a/frontend/src/main/components/Jobs/JobsTable.js
+++ b/frontend/src/main/components/Jobs/JobsTable.js
@@ -21,7 +21,7 @@ export default function JobsTable({ jobs }) {
     PlaintextColumn("Log", (cell) => {
       const logLines = cell.row.original.log.split("\n");
       const truncatedLog =
-        logLines.length > 10
+        logLines.length >= 10
           ? logLines.slice(0, 10).join("\n") + "\n..."
           : cell.row.original.log;
       return truncatedLog;

--- a/frontend/src/main/components/Jobs/JobsTable.js
+++ b/frontend/src/main/components/Jobs/JobsTable.js
@@ -18,7 +18,11 @@ export default function JobsTable({ jobs }) {
       Header: "Status",
       accessor: "status",
     },
-    PlaintextColumn("Log", (cell) => cell.row.original.log),
+    PlaintextColumn("Log", (cell) => {
+      const logLines = cell.row.original.log.split("\n");
+      const truncatedLog = logLines.length > 10 ? logLines.slice(0, 10).join("\n") + "\n..." : cell.row.original.log;
+      return truncatedLog;
+    }),
   ];
 
   const sortees = React.useMemo(

--- a/frontend/src/main/components/Jobs/JobsTable.js
+++ b/frontend/src/main/components/Jobs/JobsTable.js
@@ -36,7 +36,7 @@ export default function JobsTable({ jobs }) {
       },
     ],
     // Stryker disable next-line all
-    []
+    [],
   );
 
   return (

--- a/frontend/src/main/components/Jobs/JobsTable.js
+++ b/frontend/src/main/components/Jobs/JobsTable.js
@@ -21,7 +21,7 @@ export default function JobsTable({ jobs }) {
     PlaintextColumn("Log", (cell) => {
       const logLines = cell.row.original.log.split("\n");
       const truncatedLog =
-        logLines.length >= 10
+        logLines.length > 10
           ? logLines.slice(0, 10).join("\n") + "\n..."
           : cell.row.original.log;
       return truncatedLog;

--- a/frontend/src/main/components/Jobs/JobsTable.js
+++ b/frontend/src/main/components/Jobs/JobsTable.js
@@ -20,7 +20,10 @@ export default function JobsTable({ jobs }) {
     },
     PlaintextColumn("Log", (cell) => {
       const logLines = cell.row.original.log.split("\n");
-      const truncatedLog = logLines.length > 10 ? logLines.slice(0, 10).join("\n") + "\n..." : cell.row.original.log;
+      const truncatedLog =
+        logLines.length > 10
+          ? logLines.slice(0, 10).join("\n") + "\n..."
+          : cell.row.original.log;
       return truncatedLog;
     }),
   ];
@@ -33,7 +36,7 @@ export default function JobsTable({ jobs }) {
       },
     ],
     // Stryker disable next-line all
-    [],
+    []
   );
 
   return (

--- a/frontend/src/tests/components/Jobs/JobsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsTable.test.js
@@ -96,4 +96,48 @@ describe("JobsTable tests", () => {
       screen.getByTestId(`JobsTable-cell-row-0-col-Log`),
     ).toHaveTextContent(expectedLogContent);
   });
+
+  test("Does not add ellipsis when logLines.length is less than or equal to 10", () => {
+    const shortLog = Array.from(
+      { length: 10 },
+      (_, index) => `Line ${index + 1}`,
+    ).join("");
+    const jobsWithShortLog = [{ ...jobsFixtures.sixJobs[0], log: shortLog }];
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsTable jobs={jobsWithShortLog} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedLogContent = shortLog;
+    expect(
+      screen.getByTestId(`JobsTable-cell-row-0-col-Log`),
+    ).toHaveTextContent(expectedLogContent);
+  });
+
+  // Add a test for the exact format of the output
+  test("Renders the log text with newline characters and ellipsis when it exceeds 10 lines", () => {
+    const longLog = Array.from(
+      { length: 15 },
+      (_, index) => `Line ${index + 1}`,
+    ).join("\n");
+    const jobsWithLongLog = [{ ...jobsFixtures.sixJobs[0], log: longLog }];
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsTable jobs={jobsWithLongLog} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedLogContent =
+      "Line 1Line 2Line 3Line 4Line 5Line 6Line 7Line 8Line 9Line 10...";
+    expect(
+      screen.getByTestId(`JobsTable-cell-row-0-col-Log`),
+    ).toHaveTextContent(expectedLogContent);
+  });
 });

--- a/frontend/src/tests/components/Jobs/JobsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsTable.test.js
@@ -92,16 +92,16 @@ describe("JobsTable tests", () => {
 
     const expectedLogContent =
       "Line 1Line 2Line 3Line 4Line 5Line 6Line 7Line 8Line 9Line 10...";
-    expect(
-      screen.getByTestId(`JobsTable-cell-row-0-col-Log`),
-    ).toHaveTextContent(expectedLogContent);
+    expect(screen.getByTestId(`JobsTable-cell-row-0-col-Log`).textContent).toBe(
+      expectedLogContent,
+    );
   });
 
   test("Does not add ellipsis when logLines.length is less than or equal to 10", () => {
     const shortLog = Array.from(
       { length: 10 },
       (_, index) => `Line ${index + 1}`,
-    ).join("");
+    ).join("\n");
     const jobsWithShortLog = [{ ...jobsFixtures.sixJobs[0], log: shortLog }];
 
     render(
@@ -112,10 +112,11 @@ describe("JobsTable tests", () => {
       </QueryClientProvider>,
     );
 
-    const expectedLogContent = shortLog;
-    expect(
-      screen.getByTestId(`JobsTable-cell-row-0-col-Log`),
-    ).toHaveTextContent(expectedLogContent);
+    const expectedLogContent =
+      "Line 1Line 2Line 3Line 4Line 5Line 6Line 7Line 8Line 9Line 10";
+    expect(screen.getByTestId(`JobsTable-cell-row-0-col-Log`).textContent).toBe(
+      expectedLogContent,
+    );
   });
 
   // Add a test for the exact format of the output
@@ -135,9 +136,9 @@ describe("JobsTable tests", () => {
     );
 
     const expectedLogContent =
-      "Line 1Line 2Line 3Line 4Line 5Line 6Line 7Line 8Line 9Line 10...";
-    expect(
-      screen.getByTestId(`JobsTable-cell-row-0-col-Log`),
-    ).toHaveTextContent(expectedLogContent);
+      '<pre data-testid="plaintext"><span>Line 1</span><br><span>Line 2</span><br><span>Line 3</span><br><span>Line 4</span><br><span>Line 5</span><br><span>Line 6</span><br><span>Line 7</span><br><span>Line 8</span><br><span>Line 9</span><br><span>Line 10</span><br><span>...</span></pre>';
+    expect(screen.getByTestId(`JobsTable-cell-row-0-col-Log`).innerHTML).toBe(
+      expectedLogContent,
+    );
   });
 });

--- a/frontend/src/tests/components/Jobs/JobsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsTable.test.js
@@ -23,7 +23,7 @@ describe("JobsTable tests", () => {
         <MemoryRouter>
           <JobsTable jobs={jobsFixtures.sixJobs} />
         </MemoryRouter>
-      </QueryClientProvider>,
+      </QueryClientProvider>
     );
 
     const expectedHeaders = ["id", "Created", "Updated", "Status", "Log"];
@@ -41,23 +41,55 @@ describe("JobsTable tests", () => {
     });
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-      "1",
+      "1"
     );
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-Created`),
+      screen.getByTestId(`${testId}-cell-row-0-col-Created`)
     ).toHaveTextContent("1");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-Updated`),
+      screen.getByTestId(`${testId}-cell-row-0-col-Updated`)
     ).toHaveTextContent("11/13/2022, 19:49:59");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-status`),
+      screen.getByTestId(`${testId}-cell-row-0-col-status`)
     ).toHaveTextContent("complete");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-Log`),
+      screen.getByTestId(`${testId}-cell-row-0-col-Log`)
     ).toHaveTextContent("Hello World! from test job!Goodbye from test job!");
 
     expect(
-      screen.getByTestId(`JobsTable-header-id-sort-carets`),
+      screen.getByTestId(`JobsTable-header-id-sort-carets`)
     ).toHaveTextContent("🔽");
+  });
+
+  test("Truncates the log text correctly", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsTable jobs={jobsFixtures.sixJobs} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(
+      screen.getByTestId(`JobsTable-cell-row-0-col-Log`)
+    ).toHaveTextContent("Hello World! from test job!Goodbye from test job!");
+  });
+
+  test("Renders the log text with ellipsis when it exceeds 10 lines", () => {
+    const longLog = Array.from({ length: 15 }, (_, index) => `Line ${index + 1}`).join("\n");
+    const jobsWithLongLog = [{ ...jobsFixtures.sixJobs[0], log: longLog }];
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <JobsTable jobs={jobsWithLongLog} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const expectedLogContent = "Line 1Line 2Line 3Line 4Line 5Line 6Line 7Line 8Line 9Line 10...";
+    expect(
+      screen.getByTestId(`JobsTable-cell-row-0-col-Log`)
+    ).toHaveTextContent(expectedLogContent);
   });
 });

--- a/frontend/src/tests/components/Jobs/JobsTable.test.js
+++ b/frontend/src/tests/components/Jobs/JobsTable.test.js
@@ -23,7 +23,7 @@ describe("JobsTable tests", () => {
         <MemoryRouter>
           <JobsTable jobs={jobsFixtures.sixJobs} />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     const expectedHeaders = ["id", "Created", "Updated", "Status", "Log"];
@@ -41,23 +41,23 @@ describe("JobsTable tests", () => {
     });
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-      "1"
+      "1",
     );
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-Created`)
+      screen.getByTestId(`${testId}-cell-row-0-col-Created`),
     ).toHaveTextContent("1");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-Updated`)
+      screen.getByTestId(`${testId}-cell-row-0-col-Updated`),
     ).toHaveTextContent("11/13/2022, 19:49:59");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-status`)
+      screen.getByTestId(`${testId}-cell-row-0-col-status`),
     ).toHaveTextContent("complete");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-Log`)
+      screen.getByTestId(`${testId}-cell-row-0-col-Log`),
     ).toHaveTextContent("Hello World! from test job!Goodbye from test job!");
 
     expect(
-      screen.getByTestId(`JobsTable-header-id-sort-carets`)
+      screen.getByTestId(`JobsTable-header-id-sort-carets`),
     ).toHaveTextContent("🔽");
   });
 
@@ -67,16 +67,19 @@ describe("JobsTable tests", () => {
         <MemoryRouter>
           <JobsTable jobs={jobsFixtures.sixJobs} />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     expect(
-      screen.getByTestId(`JobsTable-cell-row-0-col-Log`)
+      screen.getByTestId(`JobsTable-cell-row-0-col-Log`),
     ).toHaveTextContent("Hello World! from test job!Goodbye from test job!");
   });
 
   test("Renders the log text with ellipsis when it exceeds 10 lines", () => {
-    const longLog = Array.from({ length: 15 }, (_, index) => `Line ${index + 1}`).join("\n");
+    const longLog = Array.from(
+      { length: 15 },
+      (_, index) => `Line ${index + 1}`,
+    ).join("\n");
     const jobsWithLongLog = [{ ...jobsFixtures.sixJobs[0], log: longLog }];
 
     render(
@@ -84,12 +87,13 @@ describe("JobsTable tests", () => {
         <MemoryRouter>
           <JobsTable jobs={jobsWithLongLog} />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
-    const expectedLogContent = "Line 1Line 2Line 3Line 4Line 5Line 6Line 7Line 8Line 9Line 10...";
+    const expectedLogContent =
+      "Line 1Line 2Line 3Line 4Line 5Line 6Line 7Line 8Line 9Line 10...";
     expect(
-      screen.getByTestId(`JobsTable-cell-row-0-col-Log`)
+      screen.getByTestId(`JobsTable-cell-row-0-col-Log`),
     ).toHaveTextContent(expectedLogContent);
   });
 });


### PR DESCRIPTION
In this PR, I have modified the Job Table to show only the first 10 lines when a job log is longer than 10 lines. Otherwise, when the log output is less than 10 lines, the entire output is displayed. This is part 1 for the EPIC issue.
![image](https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-4/assets/146385625/53f90a16-2851-491e-be4c-dec261ba953c)

Closes: #62 
