### PR TITLE
azhou - SectionsOverTimeTable More-info Button

### DIFF
--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -1,5 +1,6 @@
 import SectionsOverTimeTableBase from "main/components/SectionsOverTimeTableBase";
-
+import { ButtonColumn } from "main/components/OurTable";
+import { useNavigate } from "react-router-dom";
 import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
 import {
   convertToFraction,
@@ -20,13 +21,16 @@ function getCourseId(courseIds) {
 }
 
 export default function SectionsOverTimeTable({ sections }) {
-  // Stryker enable all
-  // Stryker disable BooleanLiteral
+  const navigate = useNavigate();
+  const detailsCallback = (cell) => {
+    navigate(
+      `/coursedetails/${cell.row.values.quarter}/${cell.row.values.enrollCode}`,
+    );
+  };
   const columns = [
     {
       Header: "Quarter",
       accessor: (row) => yyyyqToQyy(row.courseInfo.quarter),
-      disableGroupBy: true,
       id: "quarter",
 
       Cell: ({ cell: { value } }) => value,
@@ -34,7 +38,6 @@ export default function SectionsOverTimeTable({ sections }) {
     {
       Header: "Course ID",
       accessor: "courseInfo.courseId",
-      disableGroupBy: true,
 
       aggregate: getCourseId,
       Aggregated: ({ cell: { value } }) => `${value}`,
@@ -44,7 +47,6 @@ export default function SectionsOverTimeTable({ sections }) {
     {
       Header: "Title",
       accessor: "courseInfo.title",
-      disableGroupBy: true,
 
       aggregate: getFirstVal,
       Aggregated: ({ cell: { value } }) => `${value}`,
@@ -60,7 +62,6 @@ export default function SectionsOverTimeTable({ sections }) {
       Header: "Enrolled",
       accessor: (row) =>
         convertToFraction(row.section.enrolledTotal, row.section.maxEnroll),
-      disableGroupBy: true,
       id: "enrolled",
 
       aggregate: getFirstVal,
@@ -69,7 +70,6 @@ export default function SectionsOverTimeTable({ sections }) {
     {
       Header: "Status",
       accessor: (row) => formatStatus(row.section),
-      disableGroupBy: true,
       id: "status",
 
       aggregate: getFirstVal,
@@ -78,7 +78,6 @@ export default function SectionsOverTimeTable({ sections }) {
     {
       Header: "Location",
       accessor: (row) => formatLocation(row.section.timeLocations),
-      disableGroupBy: true,
       id: "location",
 
       aggregate: getFirstVal,
@@ -87,7 +86,6 @@ export default function SectionsOverTimeTable({ sections }) {
     {
       Header: "Days",
       accessor: (row) => formatDays(row.section.timeLocations),
-      disableGroupBy: true,
       id: "days",
 
       aggregate: getFirstVal,
@@ -96,7 +94,6 @@ export default function SectionsOverTimeTable({ sections }) {
     {
       Header: "Time",
       accessor: (row) => formatTime(row.section.timeLocations),
-      disableGroupBy: true,
       id: "time",
 
       aggregate: getFirstVal,
@@ -105,7 +102,6 @@ export default function SectionsOverTimeTable({ sections }) {
     {
       Header: "Instructor",
       accessor: (row) => formatInstructors(row.section.instructors),
-      disableGroupBy: true,
       id: "instructor",
 
       aggregate: getFirstVal,
@@ -114,7 +110,7 @@ export default function SectionsOverTimeTable({ sections }) {
     {
       Header: "Enroll Code",
       accessor: "section.enrollCode",
-      disableGroupBy: true,
+      id: "enrollCode",
 
       aggregate: getFirstVal,
       Aggregated: ({ cell: { value } }) => `${value}`,
@@ -123,7 +119,12 @@ export default function SectionsOverTimeTable({ sections }) {
 
   const testid = "SectionsOverTimeTable";
 
-  const columnsToDisplay = columns;
+  const buttonColumns = [
+    ...columns,
+    ButtonColumn("ⓘ", "primary", detailsCallback, "SectionsOverTimeTable"),
+  ];
+
+  const columnsToDisplay = buttonColumns;
 
   return (
     <SectionsOverTimeTableBase

--- a/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import {
   fiveSections,
   sixSections,
@@ -59,7 +59,7 @@ describe("Section tests", () => {
       "days",
       "time",
       "instructor",
-      "section.enrollCode",
+      "enrollCode",
     ];
     const testId = "SectionsOverTimeTable";
 
@@ -132,7 +132,7 @@ describe("Section tests", () => {
       "days",
       "time",
       "instructor",
-      "section.enrollCode",
+      "enrollCode",
     ];
     const testId = "SectionsOverTimeTable";
 
@@ -173,8 +173,13 @@ describe("Section tests", () => {
       screen.getByTestId(`${testId}-cell-row-0-col-instructor`),
     ).toHaveTextContent("LOKSHTANOV D");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-section.enrollCode`),
+      screen.getByTestId(`${testId}-cell-row-0-col-enrollCode`),
     ).toHaveTextContent("08078");
+    const detailsButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-ⓘ-button`,
+    );
+    expect(detailsButton).toBeInTheDocument();
+    expect(detailsButton).toHaveClass("btn-primary");
   });
 
   test("Correctly groups separate quarters of the same class", async () => {
@@ -227,6 +232,32 @@ describe("Section tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-2-col-enrolled`),
     ).toHaveTextContent("21/21");
+  });
+
+  test("Details button navigates to the details page", async () => {
+    const testId = "SectionsOverTimeTable";
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsOverTimeTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+
+    const detailsButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-ⓘ-button`,
+    );
+    expect(detailsButton).toBeInTheDocument();
+
+    fireEvent.click(detailsButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/coursedetails/S22/12591"),
+    );
   });
 
   test("all course statuses", () => {


### PR DESCRIPTION
In this PR, we add a more-info column and button to the SectionsOverTimeTable that redirects the user to the corresponding course details page.

Dokku Link: https://proj-courses-apzhou0-dev.dokku-12.cs.ucsb.edu/

To test, click on "other searches" and then "course history."

<img width="860" alt="image" src="https://github.com/ucsb-cs156-f23/proj-courses-f23-7pm-4/assets/91772918/578c1460-4e4a-4895-9876-84dd956974f6">

SectionsOverTimeTable Storybook Link: https://ucsb-cs156-f23.github.io/proj-courses-f23-7pm-4/prs/71/storybook/?path=/docs/components-sections-sectionsovertimetable--empty

Closes #50 